### PR TITLE
Update __init__.py

### DIFF
--- a/Code/Managers/__init__.py
+++ b/Code/Managers/__init__.py
@@ -1,27 +1,41 @@
 import os
 import importlib
+import inspect
 
 # Get the directory of the current file
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
-# Initialize an empty list to store all module names
+# Initialize an empty list to store all class names
 __all__ = []
 
 # Iterate through all .py files in the current directory
 for filename in os.listdir(current_dir):
-          if filename.endswith('.py') and filename != '__init__.py':
-                    module_name = filename[:-3]  # Remove the .py extension
+    if filename.endswith('.py') and filename != '__init__.py':
+        module_name = filename[:-3]  # Remove the .py extension
 
-                    # Import the module
-                    module = importlib.import_module(f'.{module_name}', package=__package__)
+        # Import the module dynamically
+        try:
+            module = importlib.import_module(f'.{module_name}', package=__package__)
+        except ImportError as e:
+            print(f"Warning: Failed to import {module_name}: {e}")
+            continue
 
-                    # Add all classes from the module to __all__
-                    for attribute_name in dir(module):
-                              attribute = getattr(module, attribute_name)
-                              if isinstance(attribute, type):  # Check if it's a class
-                                        globals()[attribute_name] = attribute
-                                        __all__.append(attribute_name)
+        # Get all classes defined in the module
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            # Only include classes defined in this module (not imported)
+            if obj.__module__ == module.__name__:
+                __all__.append(name)
 
-# Remove empty string if it exists in __all__
-if '' in __all__:
-          __all__.remove('')
+# Remove duplicates and sort for consistency
+__all__ = sorted(set(__all__))
+
+# Optional: Function to dynamically access a class by name
+def get_class_by_name(class_name):
+    """Retrieve a class by its name from any module in the current directory."""
+    for filename in os.listdir(current_dir):
+        if filename.endswith('.py') and filename != '__init__.py':
+            module_name = filename[:-3]
+            module = importlib.import_module(f'.{module_name}', package=__package__)
+            if hasattr(module, class_name) and inspect.isclass(getattr(module, class_name)):
+                return getattr(module, class_name)
+    raise AttributeError(f"Class '{class_name}' not found in any module.")


### PR DESCRIPTION
1. Cleaner Namespace Management What Changed: Removed globals()[attribute_name] = attribute, so classes are no longer injected into the global namespace.

Why It’s Better: Avoids name conflicts and keeps the __init__.py module’s namespace clean. The __all__ list still exposes the class names for import purposes (e.g., from package import *), but the actual class objects remain in their respective modules until explicitly accessed.

2. More Efficient Class Detection What Changed: Replaced dir(module) and isinstance(attribute, type) with inspect.getmembers(module, inspect.isclass).

Why It’s Better: The inspect module is designed for introspection and filters classes directly, reducing unnecessary checks. Additionally, obj.__module__ == module.__name__ ensures we only include classes defined in the module, not imported ones, avoiding clutter in __all__.

3. Improved Safety What Changed: Added a try-except block around importlib.import_module to handle import errors gracefully.

Why It’s Better: If a module fails to import (e.g., due to syntax errors or missing dependencies), the code logs a warning and continues, preventing crashes. You could further enhance security by adding a whitelist of allowed module names if needed.

4. Duplicate Handling and Consistency What Changed: Used sorted(set(__all__)) to remove duplicates and sort the list.

Why It’s Better: Ensures __all__ is unique and predictable, making it easier to debug and use. This also handles cases where multiple modules might define classes with the same name (though only one would be accessible via get_class_by_name).

5. Added Flexibility with get_class_by_name What Changed: Added an optional utility function get_class_by_name to retrieve class objects dynamically.

Why It’s Better: Provides a programmatic way to access classes without polluting the namespace or requiring direct imports. For example, MyClass = get_class_by_name('MyClass') retrieves the class object from its module.